### PR TITLE
introduce logrus proxying

### DIFF
--- a/logrus.go
+++ b/logrus.go
@@ -1,0 +1,63 @@
+package pluginapi
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/mattermost/mattermost-server/plugin"
+	"github.com/sirupsen/logrus"
+)
+
+// LogrusHook is a logrus.Hook for emitting plugin logs through the RPC API for inclusion in the
+// server logs.
+//
+// To configure the default Logrus logger for use with plugin logging, simply invoke:
+//
+//   pluginapi.ConfigureLogrus(logrus.StandardLogger)
+//
+// Alternatively, construct your own logger to pass to pluginapi.ConfigureLogrus.
+type LogrusHook struct {
+	API plugin.API
+}
+
+// NewLogrusHook creates a new instance of LogrusHook.
+func NewLogrusHook(api plugin.API) *LogrusHook {
+	return &LogrusHook{
+		API: api,
+	}
+}
+
+// Levels allows LogrusHook to process any log level.
+func (lh *LogrusHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+// Fire proxies logrus entries through the plugin API at the appropriate level.
+func (lh *LogrusHook) Fire(entry *logrus.Entry) error {
+	fields := []interface{}{}
+	for key, value := range entry.Data {
+		fields = append(fields, key)
+		fields = append(fields, fmt.Sprintf("%+v", value))
+	}
+
+	switch entry.Level {
+	case logrus.PanicLevel, logrus.FatalLevel, logrus.ErrorLevel:
+		lh.API.LogError(entry.Message, fields...)
+	case logrus.WarnLevel:
+		lh.API.LogWarn(entry.Message, fields...)
+	case logrus.InfoLevel:
+		lh.API.LogInfo(entry.Message, fields...)
+	case logrus.DebugLevel, logrus.TraceLevel:
+		lh.API.LogDebug(entry.Message, fields...)
+	}
+
+	return nil
+}
+
+// ConfigureLogrus configures the given logrus logger with a hook to proxy through the RPC API,
+// discarding the default output to avoid duplicating the events across the standard STDOUT proxy.
+func ConfigureLogrus(logger *logrus.Logger, api plugin.API) {
+	hook := NewLogrusHook(api)
+	logger.Hooks.Add(hook)
+	logger.SetOutput(ioutil.Discard)
+}

--- a/logrus_test.go
+++ b/logrus_test.go
@@ -1,0 +1,65 @@
+package pluginapi_test
+
+import (
+	"pluginapi"
+	"testing"
+
+	"github.com/mattermost/mattermost-server/plugin/plugintest"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogrus(t *testing.T) {
+	testCases := []struct {
+		Level   logrus.Level
+		APICall string
+	}{
+		{logrus.PanicLevel, "LogError"},
+		{logrus.FatalLevel, "LogError"},
+		{logrus.ErrorLevel, "LogError"},
+		{logrus.WarnLevel, "LogWarn"},
+		{logrus.InfoLevel, "LogInfo"},
+		{logrus.DebugLevel, "LogDebug"},
+		{logrus.TraceLevel, "LogDebug"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Level.String(), func(t *testing.T) {
+			logger := logrus.New()
+			logger.SetLevel(logrus.TraceLevel) // not testing logrus filtering
+
+			api := &plugintest.API{}
+			defer api.AssertExpectations(t)
+
+			pluginapi.ConfigureLogrus(logger, api)
+
+			// Parameter order of map is non-deterministic, so expect either.
+			api.On(testCase.APICall, "message", "a", "a", "b", "1").Maybe()
+			api.On(testCase.APICall, "message", "b", "1", "a", "a").Maybe()
+
+			entry := logger.WithFields(logrus.Fields{
+				"a": "a",
+				"b": 1,
+			})
+
+			if testCase.Level == logrus.PanicLevel {
+				done := make(chan bool)
+				go func() {
+					defer func() {
+						r := recover()
+						assert.NotNil(t, r, "expected panic")
+						close(done)
+					}()
+
+					entry.Panic("message")
+				}()
+				<-done
+			} else {
+				entry.Log(testCase.Level, "message")
+			}
+
+			// Assert the required API call was executed at most once.
+			api.AssertNumberOfCalls(t, testCase.APICall, 1)
+		})
+	}
+}


### PR DESCRIPTION
`LogrusHook` is a `logrus.Hook` for emitting plugin logs through the RPC API for inclusion in the server logs. To configure the default `Logrus` logger for use with plugin logging, simply invoke:

```go
pluginapi.ConfigureLogrus(logrus.StandardLogger)
```

Alternatively, construct your own logger to pass to pluginapi.ConfigureLogrus. A more complete example:

```go
func (p *Plugin) OnActivate() error {
	pluginapi.ConfigureLogrus(logrus.StandardLogger(), p.API)
	logrus.SetLevel(logrus.TraceLevel)

	return nil
}

// ServeHTTP demonstrates a plugin that handles HTTP requests by greeting the world.
func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Request) {
	logrus.Error("ERROR")
	logrus.Warn("WARN")
	logrus.Info("INFO")
	logrus.Debug("DEBUG")
	logrus.Trace("TRACE")

	logrus.WithField("test", "bob").Debug("DEBUG WITH FIELDS")
	logrus.WithFields(logrus.Fields{"test": "bob", "test2": 2, "r": r}).Debug("DEBUG WITH FIELDS")

	fmt.Fprint(w, "Hello, world!")
}
```

yields:
```
{"level":"error","ts":1574445629.807302,"caller":"mlog/sugar.go:23","msg":"ERROR","plugin_id":"com.mattermost.plugin-starter-template"}
{"level":"warn","ts":1574445629.8075871,"caller":"mlog/sugar.go:27","msg":"WARN","plugin_id":"com.mattermost.plugin-starter-template"}
{"level":"info","ts":1574445629.807837,"caller":"mlog/sugar.go:19","msg":"INFO","plugin_id":"com.mattermost.plugin-starter-template"}
{"level":"debug","ts":1574445629.808085,"caller":"mlog/sugar.go:15","msg":"DEBUG","plugin_id":"com.mattermost.plugin-starter-template"}
{"level":"debug","ts":1574445629.808286,"caller":"mlog/sugar.go:15","msg":"TRACE","plugin_id":"com.mattermost.plugin-starter-template"}
{"level":"debug","ts":1574445629.808502,"caller":"mlog/sugar.go:15","msg":"DEBUG WITH FIELDS","plugin_id":"com.mattermost.plugin-starter-template","test":"bob"} 
{"level":"debug","ts":1574445629.8088388,"caller":"mlog/sugar.go:15","msg":"DEBUG WITH FIELDS","plugin_id":"com.mattermost.plugin-starter-template","test":"bob","test2":"2","r":"&{Method:POST URL: Proto:HTTP/1.1 ProtoMajor:1 ProtoMinor:1 Header:map[Accept:[application/jso n, */*] Accept-Encoding:[gzip] Connection:[keep-alive] Content-Length:[0] User-Agent:[HTTPie/1.0.3] Username:[bot] X-Requested-With:[XMLHttpRequest] X-Requestedwith:[XMLHttpRequest]] Body:0xc0000205b0 GetBody:<nil> ContentLength:0 TransferEncoding:[] Close:false Host:loca lhost:8065 Form:map[] PostForm:map[] MultipartForm:<nil> Trailer:map[] RemoteAddr:[::1]:53111 RequestURI:/plugins/com.mattermost.plugin-starter-template TLS:<nil> Cancel:<nil> Response:<nil> ctx:<nil>}"}
```