### PR TITLE
bootstrap client and user service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # mattermost-plugin-api
 A hackathon project to explore reworking the Mattermost Plugin API.
+
+The plugin API as exposed in [github.com/mattermost/mattermost-server/plugin](http://github.com/mattermost/mattermost-server/plugin) began with the hope of adopting a consistent interface and style. But our vision for how to structure the API changed over time, along with our ability to remain consistent. 
+
+Fixing the API in place is difficult. Any backwards incompatible changes to the RPC API would break existing plugins. Even backwards incompatible changes to the plugin helpers would break semver, requiring a coordinated major version bump with parent repository. Adding new methods improves the experience for newer plugins, but forever clutters the [plugin GoDoc](https://godoc.org/github.com/mattermost/mattermost-server/plugin).
+
+Instead, we opted to wrap the existing RPC API and helpers with a client hosted in this separate repository. Issues fixed and improvements added include:
+* `*model.AppError` eliminated, safely returning an `error` interface instead
+* TBD
+
+The API exposed by this client officially replaces direct use of the RPC API and helpers. While we will maintain backwards compatibility with the existing RPC API, we may bump the major version of this repository in coordination with a breaking semver change. This will affect only plugin authors who opt in to the newer package, and existing plugins will continue to compile and run without changes using the older version of the package.
+
+Usage of this package is altogether optional, allowing plugin authors to switch to this package as needed. However, note that all new helpers and abstractions over the RPC API are expected to be added only to this package.

--- a/client.go
+++ b/client.go
@@ -1,0 +1,18 @@
+package pluginapi
+
+import "github.com/mattermost/mattermost-server/v5/plugin"
+
+// Client is a streamlined wrapper over the mattermost plugin API.
+type Client struct {
+	api plugin.API
+
+	User UserService
+}
+
+// NewClient creates a new instance of Client.
+func NewClient(api plugin.API) *Client {
+	return &Client{
+		api:  api,
+		User: UserService{api},
+	}
+}

--- a/error.go
+++ b/error.go
@@ -1,0 +1,24 @@
+package pluginapi
+
+import "github.com/mattermost/mattermost-server/v5/model"
+
+// normalizeAppError returns a truly nil error if appErr is nil.
+//
+// This doesn't happen automatically when a *model.AppError is cast to an error, since the
+// resulting error interface has a concrete type with a nil value. This leads to the seemingly
+// impossible:
+//
+//     var err error
+//     err = func() *model.AppError { return nil }()
+//     if err != nil {
+//         panic("err != nil, which surprises most")
+//     }
+//
+// Fix this problem for all plugin authors by normalizing to special case the handling of a nil
+// *model.AppError. See https://golang.org/doc/faq#nil_error for more details.
+func normalizeAppErr(appErr *model.AppError) error {
+	if appErr == nil {
+		return nil
+	}
+	return appErr
+}

--- a/example_client_test.go
+++ b/example_client_test.go
@@ -1,0 +1,20 @@
+package pluginapi_test
+
+import (
+	"pluginapi"
+
+	"github.com/mattermost/mattermost-server/v5/plugin"
+)
+
+type Plugin struct {
+	plugin.MattermostPlugin
+	client *pluginapi.Client
+}
+
+func (p *Plugin) OnActivate() error {
+	p.client = pluginapi.NewClient(p.API)
+	return nil
+}
+
+func Example() {
+}

--- a/user.go
+++ b/user.go
@@ -1,0 +1,83 @@
+package pluginapi
+
+import (
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v5/plugin"
+)
+
+// UserService exposes methods to read and write the users of a Mattermost server.
+type UserService struct {
+	api plugin.API
+}
+
+// CreateUser creates a user.
+//
+// Minimum server version: 5.2
+func (u *UserService) CreateUser(user *model.User) (*model.User, error) {
+	user, appErr := u.api.CreateUser(user)
+
+	return user, normalizeAppErr(appErr)
+}
+
+// DeleteUser deletes a user.
+//
+// Minimum server version: 5.2
+func (u *UserService) DeleteUser(userID string) error {
+	appErr := u.api.DeleteUser(userID)
+
+	return normalizeAppErr(appErr)
+}
+
+// GetUsers a list of users based on search options.
+//
+// Minimum server version: 5.10
+func (u *UserService) GetUsers(options *model.UserGetOptions) ([]*model.User, error) {
+	users, appErr := u.api.GetUsers(options)
+
+	return users, normalizeAppErr(appErr)
+}
+
+// GetUser gets a user.
+//
+// Minimum server version: 5.2
+func (u *UserService) GetUser(userID string) (*model.User, error) {
+	user, appErr := u.api.GetUser(userID)
+
+	return user, normalizeAppErr(appErr)
+}
+
+// GetUserByEmail gets a user by their email address.
+//
+// Minimum server version: 5.2
+func (u *UserService) GetUserByEmail(email string) (*model.User, error) {
+	user, appErr := u.api.GetUserByEmail(email)
+
+	return user, normalizeAppErr(appErr)
+}
+
+// GetUserByUsername gets a user by their username.
+//
+// Minimum server version: 5.2
+func (u *UserService) GetUserByUsername(username string) (*model.User, error) {
+	user, appErr := u.api.GetUserByUsername(username)
+
+	return user, normalizeAppErr(appErr)
+}
+
+// GetUsersByUsernames gets users by their usernames.
+//
+// Minimum server version: 5.6
+func (u *UserService) GetUsersByUsernames(usernames []string) ([]*model.User, error) {
+	users, appErr := u.api.GetUsersByUsernames(usernames)
+
+	return users, normalizeAppErr(appErr)
+}
+
+// GetUsersInTeam gets users in team.
+//
+// Minimum server version: 5.6
+func (u *UserService) GetUsersInTeam(teamID string, page int, perPage int) ([]*model.User, error) {
+	users, appErr := u.api.GetUsersInTeam(teamID, page, perPage)
+
+	return users, normalizeAppErr(appErr)
+}

--- a/user_test.go
+++ b/user_test.go
@@ -1,0 +1,263 @@
+package pluginapi
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v5/plugin/plugintest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateUser(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+
+		client := NewClient(api)
+
+		expectedUser := &model.User{
+			Username: "test",
+		}
+		api.On("CreateUser", expectedUser).Return(expectedUser, nil)
+
+		actualUser, err := client.User.CreateUser(expectedUser)
+		require.NoError(t, err)
+		assert.Equal(t, expectedUser, actualUser)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+
+		client := NewClient(api)
+
+		expectedUser := &model.User{
+			Username: "test",
+		}
+		api.On("CreateUser", expectedUser).Return(nil, model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError))
+
+		actualUser, err := client.User.CreateUser(expectedUser)
+		require.EqualError(t, err, "here: id, an error occurred")
+		assert.Nil(t, actualUser)
+	})
+}
+
+func TestDeleteUser(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+
+		client := NewClient(api)
+
+		expectedUserID := model.NewId()
+		api.On("DeleteUser", expectedUserID).Return(nil)
+
+		err := client.User.DeleteUser(expectedUserID)
+		require.NoError(t, err)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+
+		client := NewClient(api)
+
+		expectedUserID := model.NewId()
+		api.On("DeleteUser", expectedUserID).Return(model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError))
+
+		err := client.User.DeleteUser(expectedUserID)
+		require.EqualError(t, err, "here: id, an error occurred")
+	})
+}
+
+func TestGetUsers(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+
+		client := NewClient(api)
+
+		options := &model.UserGetOptions{}
+		expectedUsers := []*model.User{&model.User{Username: "test"}}
+		api.On("GetUsers", options).Return(expectedUsers, nil)
+
+		actualUsers, err := client.User.GetUsers(options)
+		require.NoError(t, err)
+		assert.Equal(t, expectedUsers, actualUsers)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+
+		client := NewClient(api)
+
+		options := &model.UserGetOptions{}
+		api.On("GetUsers", options).Return(nil, model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError))
+
+		actualUsers, err := client.User.GetUsers(options)
+		require.EqualError(t, err, "here: id, an error occurred")
+		assert.Nil(t, actualUsers)
+	})
+}
+
+func TestGetUser(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+
+		client := NewClient(api)
+
+		userID := "id"
+		expectedUser := &model.User{Id: userID, Username: "test"}
+		api.On("GetUser", userID).Return(expectedUser, nil)
+
+		actualUser, err := client.User.GetUser(userID)
+		require.NoError(t, err)
+		assert.Equal(t, expectedUser, actualUser)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+
+		client := NewClient(api)
+
+		userID := "id"
+		api.On("GetUser", userID).Return(nil, model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError))
+
+		actualUser, err := client.User.GetUser(userID)
+		require.EqualError(t, err, "here: id, an error occurred")
+		assert.Nil(t, actualUser)
+	})
+}
+
+func TestGetUserByEmail(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+
+		client := NewClient(api)
+
+		email := "test@example.com"
+		expectedUser := &model.User{Email: email, Username: "test"}
+		api.On("GetUserByEmail", email).Return(expectedUser, nil)
+
+		actualUser, err := client.User.GetUserByEmail(email)
+		require.NoError(t, err)
+		assert.Equal(t, expectedUser, actualUser)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+
+		client := NewClient(api)
+
+		email := "test@example.com"
+		api.On("GetUserByEmail", email).Return(nil, model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError))
+
+		actualUser, err := client.User.GetUserByEmail(email)
+		require.EqualError(t, err, "here: id, an error occurred")
+		assert.Nil(t, actualUser)
+	})
+}
+
+func TestGetUserByUsername(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+
+		client := NewClient(api)
+
+		username := "test"
+		expectedUser := &model.User{Username: username}
+		api.On("GetUserByUsername", username).Return(expectedUser, nil)
+
+		actualUser, err := client.User.GetUserByUsername(username)
+		require.NoError(t, err)
+		assert.Equal(t, expectedUser, actualUser)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+
+		client := NewClient(api)
+
+		username := "test"
+		api.On("GetUserByUsername", username).Return(nil, model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError))
+
+		actualUser, err := client.User.GetUserByUsername(username)
+		require.EqualError(t, err, "here: id, an error occurred")
+		assert.Nil(t, actualUser)
+	})
+}
+
+func TestGetUsersByUsernames(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+
+		client := NewClient(api)
+
+		usernames := []string{"test1", "test2"}
+		expectedUsers := []*model.User{&model.User{Username: "test1"}, &model.User{Username: "test2"}}
+		api.On("GetUsersByUsernames", usernames).Return(expectedUsers, nil)
+
+		actualUsers, err := client.User.GetUsersByUsernames(usernames)
+		require.NoError(t, err)
+		assert.Equal(t, expectedUsers, actualUsers)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+
+		client := NewClient(api)
+
+		usernames := []string{"test1", "test2"}
+		api.On("GetUsersByUsernames", usernames).Return(nil, model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError))
+
+		actualUsers, err := client.User.GetUsersByUsernames(usernames)
+		require.EqualError(t, err, "here: id, an error occurred")
+		assert.Nil(t, actualUsers)
+	})
+}
+
+func TestGetUsersInTeam(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+
+		client := NewClient(api)
+
+		teamID := "team_id"
+		page := 1
+		perPage := 10
+		expectedUsers := []*model.User{&model.User{Username: "test1"}, &model.User{Username: "test2"}}
+		api.On("GetUsersInTeam", teamID, page, perPage).Return(expectedUsers, nil)
+
+		actualUsers, err := client.User.GetUsersInTeam(teamID, page, perPage)
+		require.NoError(t, err)
+		assert.Equal(t, expectedUsers, actualUsers)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		api := &plugintest.API{}
+		defer api.AssertExpectations(t)
+
+		client := NewClient(api)
+
+		teamID := "team_id"
+		page := 1
+		perPage := 10
+		api.On("GetUsersInTeam", teamID, page, perPage).Return(nil, model.NewAppError("here", "id", nil, "an error occurred", http.StatusInternalServerError))
+
+		actualUsers, err := client.User.GetUsersInTeam(teamID, page, perPage)
+		require.EqualError(t, err, "here: id, an error occurred")
+		assert.Nil(t, actualUsers)
+	})
+}


### PR DESCRIPTION
This commit only solves the problem that is `*model.AppError`, but otherwise proxies through the underlying API unchanged at this time.